### PR TITLE
Fix for 6.3. Avoid import conflicts.

### DIFF
--- a/drbayes/private/arrow/indexes.rkt
+++ b/drbayes/private/arrow/indexes.rkt
@@ -1,6 +1,6 @@
 #lang typed/racket/base
 
-(require racket/list
+(require (only-in racket/list empty)
          math/flonum
          "../set.rkt"
          "../flonum.rkt"

--- a/drbayes/private/flonum/probability.rkt
+++ b/drbayes/private/flonum/probability.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require racket/performance-hint
-         racket/list
+         (only-in racket/list first rest empty? make-list)
          math/flonum
          racket/promise
          "symmetric-log.rkt"

--- a/drbayes/private/search/enumerate.rkt
+++ b/drbayes/private/search/enumerate.rkt
@@ -1,7 +1,9 @@
 #lang typed/racket/base
 
 (require racket/match
-         racket/list
+         (only-in racket/list
+                  first second rest last empty? empty take drop append*
+                  remove-duplicates)
          (prefix-in r. racket/set)
          math/statistics
          "../set.rkt"

--- a/drbayes/private/search/refinement-search.rkt
+++ b/drbayes/private/search/refinement-search.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require racket/match
-         racket/list
+         (only-in racket/list first second rest empty? empty take drop argmin)
          racket/promise
          math/flonum
          "../set.rkt"

--- a/drbayes/private/search/search-tree.rkt
+++ b/drbayes/private/search/search-tree.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require racket/match
-         racket/list
+         (only-in racket/list empty)
          racket/promise
          "../flonum.rkt"
          "../utils.rkt"

--- a/drbayes/private/set/prob-set.rkt
+++ b/drbayes/private/set/prob-set.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require racket/match
-         racket/list
+         (only-in racket/list first second rest empty?)
          math/flonum
          "ordered-set.rkt"
          "../flonum.rkt"

--- a/drbayes/private/set/store-set.rkt
+++ b/drbayes/private/set/store-set.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require racket/match
-         racket/list
+         (only-in racket/list first rest empty? empty)
          racket/promise
          "types.rkt"
          "parameters.rkt"

--- a/drbayes/private/set/store.rkt
+++ b/drbayes/private/set/store.rkt
@@ -1,6 +1,6 @@
 #lang typed/racket/base
 
-(require racket/list
+(require (only-in racket/list empty)
          racket/match
          racket/promise
          "bottom.rkt"

--- a/drbayes/private/set/union-ops.rkt
+++ b/drbayes/private/set/union-ops.rkt
@@ -1,7 +1,6 @@
 #lang typed/racket/base
 
 (require (for-syntax racket/base)
-         racket/list
          "parameters.rkt"
          "types.rkt"
          "real-set.rkt"

--- a/drbayes/private/set/union.rkt
+++ b/drbayes/private/set/union.rkt
@@ -1,7 +1,7 @@
 #lang typed/racket/base
 
 (require (for-syntax racket/base)
-         racket/list
+         (only-in racket/list first empty)
          racket/match
          math/flonum
          math/private/utils


### PR DESCRIPTION
Would be simpler to not define `list-set` here, but that wouldn't be
compatible with 6.2.1. Feel free to do that and add a version exception
for older Racket versions.
