### PR TITLE
Remove `list-set` from utils.rkt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is of course possible using rejection sampling for exponential cost, but Dr
 
 > Neil Toronto. [Trustworthy, Useful Languages for Probabilistic Modeling and Inference.](http://www.cs.umd.edu/~ntoronto/papers/toronto-2014diss.pdf) Doctoral Dissertation, Brigham Young University, 2014 (to appear).
 
-Dr. Bayes is currently just a core calculus. In the next few months, I intend to put a pretty face on it, make it faster, and turn this repository into an installable Racket package.
+Dr. Bayes is currently just a core calculus. In the next few months, I intend to put a pretty face on it and make it faster.
 
 Directories:
 
@@ -16,4 +16,8 @@ Directories:
  
  * tests: Various deterministic and randomized tests
 
-
+## Installation
+```
+# From the project root directory
+raco pkg install
+```

--- a/drbayes/private/utils.rkt
+++ b/drbayes/private/utils.rkt
@@ -36,10 +36,6 @@
         [(= i 1)  (cons (first lst) (rest (rest lst)))]
         [else  (list* (first lst) (second lst) (remove-index (rest (rest lst)) (- i 2)))]))
 
-(: list-set (All (A) ((Listof A) Integer A -> (Listof A))))
-(define (list-set lst i x)
-  (append (take lst i) (cons x (drop lst (+ i 1)))))
-
 (: list-set/+2 (All (A) ((Listof+2 A) Integer A -> (Listof+2 A))))
 (define (list-set/+2 lst i x)
   (cond [(= i 0)  (list* x (second lst) (rest (rest lst)))]


### PR DESCRIPTION
This eliminates error messages about conflicting imports with list-set
from racket/list. Jay indicates that the functions are duplicates, so
it is ok to remove.
(https://github.com/ntoronto/drbayes/issues/6#issuecomment-228868808)

This fixes #6.
